### PR TITLE
fix: implement proper auto-scroll to bottom for chat messages

### DIFF
--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -14,10 +14,9 @@ interface MessageInputProps {
   placeholder?: string;
   onTyping?: (isTyping: boolean) => void;
   channelUsers?: User[];
-  onInputResize?: () => void;
 }
 
-export default function MessageInput({ onSendMessage, placeholder = "メッセージを入力...", onTyping, channelUsers = [], onInputResize }: MessageInputProps) {
+export default function MessageInput({ onSendMessage, placeholder = "メッセージを入力...", onTyping, channelUsers = [] }: MessageInputProps) {
   const [message, setMessage] = useState('');
   const [showFileUpload, setShowFileUpload] = useState(false);
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
@@ -253,17 +252,8 @@ export default function MessageInput({ onSendMessage, placeholder = "メッセ�
             }}
             onInput={(e) => {
               const target = e.target as HTMLTextAreaElement;
-              const prevHeight = target.offsetHeight;
               target.style.height = 'auto';
-              const newHeight = Math.min(target.scrollHeight, 150);
-              target.style.height = `${newHeight}px`;
-              
-              // Trigger scroll adjustment if height changed
-              if (newHeight !== prevHeight && onInputResize) {
-                requestAnimationFrame(() => {
-                  onInputResize();
-                });
-              }
+              target.style.height = `${Math.min(target.scrollHeight, 150)}px`;
             }}
           />
         </div>


### PR DESCRIPTION
## Summary
- メッセージ送信時に自動的にページ最下部へスクロール
- 他のユーザーのメッセージ受信時は、ユーザーが既に最下部にいる場合のみスクロール
- メッセージ履歴を見ている時はスクロール位置を維持
- ローディングインジケーターによる不要なスクロールを防止

## Changes
- `ChatRoom.tsx`: スマートなスクロール判定とユーザー送信フラグの追加
- `MessageInput.tsx`: 不要なonInputResizeコールバックを削除
- `loadMessages()`: バックグラウンド更新時はローディング表示を無効化

## Test plan
- [x] メッセージ送信時の自動スクロール動作確認
- [x] 他ユーザーメッセージ受信時のスクロール位置維持確認
- [x] スクロールアップして履歴確認中の位置維持確認
- [x] ローディング表示によるスクロール問題の解決確認

## 動作確認済み
- ✅ メッセージ送信時に最上部から最下部へのスクロールが発生しない
- ✅ 送信したメッセージが即座に表示される
- ✅ ページ最下部にフォーカスし続ける機能が正常に動作

🤖 Generated with [Claude Code](https://claude.ai/code)